### PR TITLE
Added field to manipulate priority of css inclusion

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -39,3 +39,8 @@ form:
           type: text
           label: File path
           help: Relative to web root
+        .priority:
+          type: int
+          label: Priority (0=Default)
+          help: Lower means later inclusion. Negative value to add this file after the other files (that come with the theme)
+          default: 0

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -37,3 +37,5 @@ form:
       fields:
         .path:
           type: text
+          label: File path
+          help: Relative to web root

--- a/custom-css.php
+++ b/custom-css.php
@@ -40,7 +40,7 @@ class CustomCSSPlugin extends Plugin
         $this->grav['assets']->addInlineCss($this->config->get('plugins.custom-css.css_inline'));
 
         foreach($this->config->get('plugins.custom-css.css_files') as $file) {
-            $this->grav['assets']->addCss($file['path']);    
-        }    
+            $this->grav['assets']->addCss($file['path'], isset($file['priority']) ? $file['priority'] : null);
+        }
     }
 }


### PR DESCRIPTION
This patch adds a new field to the css_files configuration to allow to specify the 'priority' in which the file will be added to the page.
